### PR TITLE
Remotes Responses queue

### DIFF
--- a/Plugins/simple-commissioning-initiator/plugin.properties
+++ b/Plugins/simple-commissioning-initiator/plugin.properties
@@ -14,7 +14,7 @@ quality=testTool
 description=Commissioning implementation based on the 075367r03 document for Initiator side
 
 # List of .c files that need to be compiled and linked in.
-sourceFiles=simple-commissioning-initiator.c,simple-commissioning-initiator-internal.c
+sourceFiles=simple-commissioning-initiator.c,simple-commissioning-initiator-internal.c,simple-commissioning-initiator-buffer.c
 
 # List of callbacks implemented by this plugin
 implementedCallbacks=emberAfIdentifyClusterIdentifyQueryResponseCallback

--- a/Plugins/simple-commissioning-initiator/simple-commissioning-initiator-buffer.c
+++ b/Plugins/simple-commissioning-initiator/simple-commissioning-initiator-buffer.c
@@ -1,0 +1,122 @@
+#include "simple-commissioning-initiator-buffer.h"
+
+/// \typedef QUEUE_SIZE
+///
+/// Handy renaming of the long name EMBER_AF_PLUGIN_SIMPLE_COMMISSIONING_INITIATOR_REMOTES_QUEUE
+#define QUEUE_SIZE EMBER_AF_PLUGIN_SIMPLE_COMMISSIONING_INITIATOR_REMOTES_QUEUE
+
+MatchDescriptorReq_t data[QUEUE_SIZE];
+
+#define RING_BUFFER_ERROR 255
+
+typedef struct RingBuffer {
+  MatchDescriptorReq_t *buffer;
+  uint8_t begin;
+  uint8_t end;
+  uint8_t size;
+  uint8_t capacity;
+} RingBuffer_t;
+
+typedef struct MatchDescriptorQueue {
+  RingBuffer_t internal_data;
+} MatchDescriptorQueue_t;
+
+static inline void InitQueueInternalData(MatchDescriptorQueue_t *queue);
+static inline bool QueueIsFull(MatchDescriptorQueue_t *queue);
+
+// Global queue
+MatchDescriptorQueue_t devices_queue;
+
+/// Ring Buffer internal functions
+static inline void RingBufferInit(RingBuffer_t *buf) {
+	buf->buffer = data;
+	buf->begin = 0;
+	buf->end = 0;
+	buf->size = 0;
+	buf->capacity = QUEUE_SIZE;
+}
+static inline bool RingBufferIsFull(RingBuffer_t *buf) {
+  return (buf->size == buf->capacity);
+}
+
+static inline bool RingBufferIsEmpty(RingBuffer_t *buf) {
+  return (buf->size == 0);
+}
+
+static inline uint8_t RingBufferSize(RingBuffer_t *buf) {
+  return buf->size;
+}
+
+static inline uint8_t RingBufferPush(RingBuffer_t *buf, const MatchDescriptorReq_t * const data) {
+  // Cicular buffer is full
+  if (RingBufferIsFull(buf)) {
+      // quit with an error
+      return RING_BUFFER_ERROR;
+  }
+
+  ++buf->size;
+  buf->buffer[buf->end] = *data;
+  buf->end = (buf->end + 1) % buf->capacity;
+  
+  return 0;
+}
+ 
+static inline uint8_t RingBufferPopFront(RingBuffer_t *buf) {
+  // if the head isn't ahead of the tail, we don't have any characters
+  if (RingBufferIsEmpty(buf)) {
+      return RING_BUFFER_ERROR;
+  }
+  
+  --buf->size;
+  buf->begin = (buf->begin + 1) % buf->capacity;
+
+  return 0;
+}
+
+static inline void *RingBufferGet(RingBuffer_t *buf) {
+  if (RingBufferIsEmpty(buf)) {
+    // quit with an error
+    return NULL;
+  }
+
+  return &buf->buffer[buf->begin];
+}
+
+static inline void InitQueueInternalData(MatchDescriptorQueue_t *queue) {
+	RingBufferInit(&queue->internal_data);
+}
+
+static inline bool QueueIsFull(MatchDescriptorQueue_t *queue) {
+	return RingBufferIsFull(&queue->internal_data);
+}
+
+// Public interface implementation
+void InitQueue(void) {
+  InitQueueInternalData(&devices_queue);
+}
+
+bool AddInDeviceDescriptor(const EmberNodeId short_id, const uint8_t endpoint) {
+  if (!QueueIsFull(&devices_queue)) {
+    MatchDescriptorReq_t in_conn = {
+      .source = short_id,
+      .source_ep = endpoint
+    };
+    
+    uint8_t status = RingBufferPush(&devices_queue.internal_data, &in_conn);
+    return (status != RING_BUFFER_ERROR) ? true : false;
+  }
+  
+  return false;
+}
+
+MatchDescriptorReq_t *GetTopInDeviceDescriptor(void) {
+  return (MatchDescriptorReq_t *) RingBufferGet(&devices_queue.internal_data);
+}
+
+void PopInDeviceDescriptor(void) {
+  RingBufferPopFront(&devices_queue.internal_data);
+}
+
+uint8_t GetQueueSize(void) {
+  return RingBufferSize(&devices_queue.internal_data);
+}

--- a/Plugins/simple-commissioning-initiator/simple-commissioning-initiator-buffer.h
+++ b/Plugins/simple-commissioning-initiator/simple-commissioning-initiator-buffer.h
@@ -1,0 +1,20 @@
+#ifndef SIMPLE_COMMISSIONING_INITIATOR_BUFFER_H
+#define SIMPLE_COMMISSIONING_INITIATOR_BUFFER_H
+
+#include "app/framework/include/af.h"
+#include "simple-commissioning-td.h"
+
+/// Initialize queue
+void InitQueue(void);
+/// Function for adding initial info about a remote device
+/// 
+/// It is necessary to pass only remote device's short ID and endpoint
+bool AddInDeviceDescriptor(const EmberNodeId short_id, const uint8_t endpoint);
+/// Function for getting the top remote device's descriptor
+MatchDescriptorReq_t *GetTopInDeviceDescriptor(void);
+/// Delete the top descriptor
+void PopInDeviceDescriptor(void);
+/// Get queue size
+uint8_t GetQueueSize(void);
+
+#endif // SIMPLE_COMMISSIONING_INITIATOR_BUFFER_H

--- a/Plugins/simple-commissioning-initiator/simple-commissioning-initiator-internal.c
+++ b/Plugins/simple-commissioning-initiator/simple-commissioning-initiator-internal.c
@@ -475,6 +475,7 @@ static CommissioningState_t BindingDone(void) {
 	emberAfDebugPrintln("DEBUG: Binding Done");
 	// as we've processed the current remote device delete it from the queue
 	SetNextEvent(SC_EZEV_CHECK_QUEUE);
+	emberEventControlSetActive(StateMachineEvent);
 
 	return SC_EZ_BIND;
 }
@@ -538,7 +539,7 @@ static CommissioningState_t CheckQuery(void) {
 
 	if (GetQueueSize() != 0) {
 		SetNextEvent(SC_EZEV_CHECK_CLUSTERS);
-		next_st = SC_EZ_MATCH;
+		next_st = SC_EZ_DISCOVER;
 	}
 	else {
 		SetNextEvent(SC_EZEV_QUEUE_EMPTY);

--- a/Plugins/simple-commissioning-initiator/simple-commissioning-initiator-internal.c
+++ b/Plugins/simple-commissioning-initiator/simple-commissioning-initiator-internal.c
@@ -256,15 +256,20 @@ boolean emberAfIdentifyClusterIdentifyQueryResponseCallback(int16u timeout) {
   if (emberAfGetNodeId() != current_cmd->source && timeout != 0) {
     emberAfDebugPrintln("DEBUG: Got ID Query response");
     emberAfDebugPrintln("DEBUG: Sender 0x%2X", emberAfCurrentCommand()->source);
+    // Queue is empty, so we can start commissioning process
+    // otherwise we push it in the queue and will process later
+    if (GetQueueSize() == 0) {
+    	// ID Query received -> go to the discover state for getting clusters info
+			emberAfDebugPrintln("DEBUG: QUEUE IS EMPTY");
+			SetNextState(SC_EZ_DISCOVER);
+			SetNextEvent(SC_EZEV_CHECK_CLUSTERS);
+			emberEventControlSetActive(StateMachineEvent);
+		}
     // Store information about endpoint and short ID of the incoming response
     // for further processing in the Matching (SC_EZ_MATCH) state
 		SetInConnBaseInfo(current_cmd->source,
 											current_cmd->apsFrame->sourceEndpoint);
-		// ID Query received -> go to the discover state for getting clusters info
-		SetNextState(SC_EZ_DISCOVER);
-		SetNextEvent(SC_EZEV_CHECK_CLUSTERS);
     emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
-    emberEventControlSetActive(StateMachineEvent);
   }
 
   return TRUE;

--- a/Plugins/simple-commissioning-initiator/simple-commissioning-td.h
+++ b/Plugins/simple-commissioning-initiator/simple-commissioning-td.h
@@ -101,7 +101,9 @@ typedef enum CommissioningEvents {
   SC_EZEV_NOT_MATCHED,
   SC_EZEV_AWAIT_EUI64,
   SC_EZEV_BIND,
+  SC_EZEV_CHECK_QUEUE,
   SC_EZEV_BINDING_DONE,
+  SC_EZEV_QUEUE_EMPTY,
   SC_EZEV_UNKNOWN = 255
 } CommissioningEvent_t;
 


### PR DESCRIPTION
Implement functionality that afford a device to store incoming responses from remote nodes and put them to the queue.
During the commissioning state a device will get all of remote devices' descriptors and process them correctly.
